### PR TITLE
Feat: Radio button group component

### DIFF
--- a/packages/ui/.storybook/preview.tsx
+++ b/packages/ui/.storybook/preview.tsx
@@ -45,7 +45,7 @@ const preview: Preview = {
     backgrounds: {
       values: [
         { name: "Dark", value: "#000" },
-        { name: "Light", value: "#E4EDE3" },
+        { name: "Light", value: "#fff" },
       ],
       default: "Light",
     },

--- a/packages/ui/src/radio-group/index.tsx
+++ b/packages/ui/src/radio-group/index.tsx
@@ -1,0 +1,52 @@
+import type { ChangeEvent } from "react";
+import {
+  RadioGroup as MUIRadioGroup,
+  Radio,
+  FormControlLabel,
+  FormControl,
+  FormLabel,
+} from "@mui/material";
+
+interface RadioGroupProps {
+  label: string;
+  inputName: string;
+  value: string;
+  children: React.ReactElement;
+  handleChange: (event: ChangeEvent<HTMLInputElement>, value: string) => void;
+}
+
+interface RadioButtonProps {
+  label: string;
+  value: string;
+}
+
+function RadioButton({ value, label }: RadioButtonProps) {
+  return <FormControlLabel value={value} control={<Radio />} label={label} />;
+}
+
+function RadioGroup({
+  label,
+  inputName,
+  value,
+  children,
+  handleChange,
+}: RadioGroupProps) {
+  return (
+    <FormControl>
+      <FormLabel id={`radio-group-${inputName}`}>{label}</FormLabel>
+      <MUIRadioGroup
+        row
+        aria-labelledby={`radio-group-${inputName}`}
+        name={inputName}
+        value={value}
+        onChange={handleChange}
+      >
+        {children}
+      </MUIRadioGroup>
+    </FormControl>
+  );
+}
+
+RadioGroup.RadioButton = RadioButton;
+
+export default RadioGroup;

--- a/packages/ui/src/radio-group/radio-group.stories.tsx
+++ b/packages/ui/src/radio-group/radio-group.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta } from "@storybook/react";
+
+import RadioGroup from ".";
+import { useState } from "react";
+
+const meta = {
+  title: "Components/RadioGroup",
+  component: RadioGroup,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  args: {},
+} as Meta;
+
+export default meta;
+
+export const Default = () => {
+  const [value, setValue] = useState<string>("deposito");
+
+  const handleChange = (value: string) => {
+    setValue(value);
+  };
+
+  return (
+    <RadioGroup
+      label="Tipo de operação"
+      inputName="tipo-de-operacao"
+      value={value}
+      handleChange={(event) => handleChange(event?.target?.value)}
+    >
+      <>
+        <RadioGroup.RadioButton label="Depósito" value="deposito" />
+        <RadioGroup.RadioButton label="Transferência" value="transferencia" />
+      </>
+    </RadioGroup>
+  );
+};

--- a/packages/ui/src/select/index.tsx
+++ b/packages/ui/src/select/index.tsx
@@ -2,6 +2,7 @@ import {
   Select as MUISelect,
   SelectChangeEvent,
   MenuItem,
+  useTheme,
 } from "@mui/material";
 
 interface SelectProps {
@@ -11,13 +12,19 @@ interface SelectProps {
 }
 
 export function Select({ onChange, options, placeholder }: SelectProps) {
+  const theme = useTheme();
+
   return (
     <MUISelect defaultValue="none" onChange={(e) => onChange(e)}>
       <MenuItem value="none" sx={{ display: "none" }}>
         <em>{placeholder}</em>
       </MenuItem>
       {options.map((option) => (
-        <MenuItem key={option.value} value={option.value}>
+        <MenuItem
+          key={option.value}
+          value={option.value}
+          sx={{ "&:hover": { backgroundColor: theme.palette.primary.light } }}
+        >
           {option.label}
         </MenuItem>
       ))}

--- a/packages/ui/src/theme/index.ts
+++ b/packages/ui/src/theme/index.ts
@@ -3,6 +3,7 @@ import { ThemeOptions } from "@mui/material";
 import { buttonOverrides } from "./overrides/button";
 import { selectOverrides } from "./overrides/select";
 import { menuItemOverrides } from "./overrides/menu-item";
+import { radioGroupOverrides } from "./overrides/radio-group";
 
 const theme = createTheme({
   palette: {
@@ -66,6 +67,7 @@ const theme = createTheme({
     ...buttonOverrides,
     ...selectOverrides,
     ...menuItemOverrides,
+    ...radioGroupOverrides,
     MuiSkeleton: {
       styleOverrides: {
         root: {

--- a/packages/ui/src/theme/overrides/radio-group.ts
+++ b/packages/ui/src/theme/overrides/radio-group.ts
@@ -1,0 +1,24 @@
+import type { Components, CssVarsTheme, Theme } from "@mui/material";
+
+export const radioGroupOverrides = {
+  MuiFormLabel: {
+    styleOverrides: {
+      root: {
+        color: "#DEE9EA",
+        fontWeight: 600,
+        fontSize: "16px",
+        marginBottom: "12px",
+        "&.Mui-focused": {
+          color: "#DEE9EA",
+        },
+      },
+    },
+  },
+  MuiFormControlLabel: {
+    styleOverrides: {
+      label: {
+        fontSize: "14px !important",
+      },
+    },
+  },
+} as Components<Omit<Theme, "components" | "palette"> & CssVarsTheme>;


### PR DESCRIPTION
### Descrição

- cria componente Radio button group
- corrige comportamento de hover no componente Select
- altera a cor de fundo padrão dos stories para tentar "melhorar"o contraste de cores e facilitar no debug dos componentes

![Captura de Tela 2024-10-21 às 12 43 29](https://github.com/user-attachments/assets/bbecc924-25ea-4c1c-aafa-975158d65b55)

![Captura de Tela 2024-10-21 às 12 43 42](https://github.com/user-attachments/assets/e8d50abd-96b4-4355-a0dd-2ca692c3d8c3)
